### PR TITLE
Update App Insights to be backed by Log Analytics Workspace rather than Classic

### DIFF
--- a/infrastructure/bicep/main.bicep
+++ b/infrastructure/bicep/main.bicep
@@ -45,6 +45,17 @@ module kv './modules/key_vault.bicep' = {
   }
 }
 
+// Log Analytics Workspace
+module log './modules/log_analytics_workspace.bicep' = {
+  name: 'log'
+  scope: resourceGroup(rg.name)
+  params: {
+    baseName: baseName
+    location: location
+    tags: tags
+  }
+}
+
 // App Insights
 module appi './modules/application_insights.bicep' = {
   name: 'appi'
@@ -52,6 +63,7 @@ module appi './modules/application_insights.bicep' = {
   params: {
     baseName: baseName
     location: location
+    workspaceResourceId: log.outputs.logOut
     tags: tags
   }
 }

--- a/infrastructure/bicep/modules/application_insights.bicep
+++ b/infrastructure/bicep/modules/application_insights.bicep
@@ -1,6 +1,8 @@
 param baseName string
 param location string
+param workspaceResourceId string
 param tags object
+
 
 // App Insights
 resource appinsight 'Microsoft.Insights/components@2020-02-02-preview' = {
@@ -9,6 +11,7 @@ resource appinsight 'Microsoft.Insights/components@2020-02-02-preview' = {
   kind: 'web'
   properties: {
     Application_Type: 'web'
+    WorkspaceResourceId: workspaceResourceId
   }
 
   tags: tags

--- a/infrastructure/bicep/modules/log_analytics_workspace.bicep
+++ b/infrastructure/bicep/modules/log_analytics_workspace.bicep
@@ -1,0 +1,16 @@
+param baseName string
+param location string
+param tags object
+
+resource log 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name:  'log-${baseName}'
+  location: location
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+  tags: tags
+}
+
+output logOut string = log.id

--- a/infrastructure/terraform/aml_deploy.tf
+++ b/infrastructure/terraform/aml_deploy.tf
@@ -69,6 +69,21 @@ module "key_vault" {
   tags = local.tags
 }
 
+# Log Analytics Workspace to back Application Insights
+
+module "log_analytics_workspace" {
+  source = "./modules/log-analytics-workspace"
+
+  rg_name  = module.resource_group.name
+  location = module.resource_group.location
+
+  prefix  = var.prefix
+  postfix = var.postfix
+  env = var.environment
+
+  tags = local.tags
+}
+
 # Application insights
 
 module "application_insights" {
@@ -80,6 +95,8 @@ module "application_insights" {
   prefix  = var.prefix
   postfix = var.postfix
   env = var.environment
+  
+  log_analytics_workspace_id = module.log_analytics_workspace.id
 
   tags = local.tags
 }

--- a/infrastructure/terraform/modules/application-insights/main.tf
+++ b/infrastructure/terraform/modules/application-insights/main.tf
@@ -3,6 +3,7 @@ resource "azurerm_application_insights" "appi" {
   location            = var.location
   resource_group_name = var.rg_name
   application_type    = "web"
+  workspace_id        = var.log_analytics_workspace_id 
 
   tags = var.tags
 }

--- a/infrastructure/terraform/modules/log-analytics-workspace/main.tf
+++ b/infrastructure/terraform/modules/log-analytics-workspace/main.tf
@@ -1,0 +1,8 @@
+resource "azurerm_log_analytics_workspace" "log" {
+  name                = "log-${var.prefix}-${var.postfix}${var.env}"
+  location            = var.location
+  resource_group_name = var.rg_name
+  sku                 = "PerGB2018"
+
+  tags = var.tags
+}

--- a/infrastructure/terraform/modules/log-analytics-workspace/outputs.tf
+++ b/infrastructure/terraform/modules/log-analytics-workspace/outputs.tf
@@ -1,0 +1,3 @@
+output "id" {
+  value = azurerm_log_analytics_workspace.log.id
+}

--- a/infrastructure/terraform/modules/log-analytics-workspace/variables.tf
+++ b/infrastructure/terraform/modules/log-analytics-workspace/variables.tf
@@ -28,8 +28,3 @@ variable "env" {
   type        = string
   description = "Environment prefix"
 }
-
-variable "log_analytics_workspace_id" {
-  type        = string
-  description = "Log Analytics Workspace Id"
-}


### PR DESCRIPTION
# PR into Azure/mlops-project-template

## Checklist

I have:

- [X] read and followed the contributing guidelines

## Changes

Previous template would create a Classic Application Insights instance, [which is being retired in February 2024](https://azure.microsoft.com/en-us/updates/we-re-retiring-classic-application-insights-on-29-february-2024/).  
- Changes made in Bicep and Terraform templates:
   - Add Log Analytics Workspace and output the id.
   - Change Application Insights to point to the Log Analytics Workspace id.

Tested locally with Terraform and Bicep
Before:
<img width="553" alt="image" src="https://github.com/t-m-crane/mlops-project-template/assets/111529455/d551df18-d13f-4d22-afb4-9df17fc1e6b5">


After:
<img width="74" alt="image" src="https://github.com/t-m-crane/mlops-project-template/assets/111529455/d73c8ea7-150f-45cb-8a3c-312d604ab27c">





